### PR TITLE
chore: nexdrew says au revoir

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ The team members are:
 
 * **[@mmalecki](https://github.com/mmalecki/)**
 * **[@soldair](https://github.com/soldair/)**
-* **[@nexdrew](https://github.com/nexdrew/)**
 * **[@chrisdickinson](https://github.com/chrisdickinson/)**
 
 ## What This Repo Is


### PR DESCRIPTION
As of 2/1/2017, nexdrew will no longer be on the registry/services team.

Good luck, my friends, it's been a blast!