### PR TITLE
Info about `latest` version

### DIFF
--- a/docs/REGISTRY-API.md
+++ b/docs/REGISTRY-API.md
@@ -119,7 +119,7 @@ This endpoint responds with the package metadata document, sometimes informally 
 | Name     | Value     | Kind     | Required?     | Notes     |
 |------    |-------    |------    |-----------    |-------    |
 | package | String | **Path** | ✅         | the name of the package |
-| version | String | **Path** | ✅         | a version number        |
+| version | String | **Path** | ✅         | a version number or `latest`        |
 
 #### `GET·/-/v1/search`
 


### PR DESCRIPTION
In order to avoid situations like [the following one](https://twitter.com/medikoo/status/847348098242232320), where both developers and `npm` registry as service lose, this PR would like to underline there is the possibility to ask for latest version instead of needing an exact number, impossible to retrieve otherwise if not by querying the whole package and its history.