### PR TITLE
Extend info about using multiple keywords with the APIs search endpoint

### DIFF
--- a/docs/REGISTRY-API.md
+++ b/docs/REGISTRY-API.md
@@ -206,7 +206,11 @@ Special search qualifiers can be provided in the full-text query:
 
 * `author:bcoe`: Show/filter results in which `bcoe` is the author
 * `maintainer:bcoe`: Show/filter results in which `bcoe` is qualifier as a maintainer
-* `keywords:batman`: Show/filter results that have `batman` in the keywords (separate multiple keywords with commas, you may also exclude keywords e.g.: `keywords:-framework,-batman`)
+* `keywords:batman`: Show/filter results that have `batman` in the keywords
+  * separating multiple keywords with
+    * `,` acts like a logical `OR`
+    * `+` acts like a logical `AND`
+    * `,-` can be used to exclude keywords
 * `not:unstable`: Exclude packages whose version is `< 1.0.0`
 * `not:insecure`: Exclude packages that are insecure or have vulnerable dependencies (based on the [nsp](https://nodesecurity.io/) registry)
 * `is:unstable`: Show/filter packages whose version is `< 1.0.0`


### PR DESCRIPTION
The possibility to use `+` was described by @bcoe over here: https://github.com/yeoman/yo/issues/544#issuecomment-340901909

Then we had a little confusion about which »operator« to use in https://github.com/sindresorhus/npm-keyword/pull/13

I finally realized by testing that it works like described in this PR 😊 

Examples:
[keywords:yeoman-generator](https://registry.npmjs.org/-/v1/search?text=keywords:yeoman-generator&size=1) ➡️ `"total": 6994`
[keywords:yeoman-generator,baumeister](https://registry.npmjs.org/-/v1/search?text=keywords:yeoman-generator,baumeister&size=1) ➡️ `"total": 6994`
[keywords:yeoman-generator+baumeister](https://registry.npmjs.org/-/v1/search?text=keywords:yeoman-generator+baumeister&size=1) ➡️ `"total": 1`
[keywords:yeoman-generator,-baumeister](https://registry.npmjs.org/-/v1/search?text=keywords:yeoman-generator,-baumeister&size=1) ➡️ `"total": 6993`
